### PR TITLE
If data is None don't call json.dumps

### DIFF
--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -456,7 +456,8 @@ class Salesforce(object):
             method,
             self.apex_url + action,
             name="apexexcute",
-            data=json.dumps(data), **kwargs
+            data=json.dumps(data) if data is not None else None,
+            **kwargs
         )
         try:
             response_content = result.json()


### PR DESCRIPTION
@courtneyod going to merge this to give us a temporary workaround. There don't seem to be any tests for apexecute